### PR TITLE
Add support for loading from serialized Json & Yaml strings

### DIFF
--- a/CodingSeb.Localization.JsonFileLoader/JsonFileLoader.cs
+++ b/CodingSeb.Localization.JsonFileLoader/JsonFileLoader.cs
@@ -54,58 +54,61 @@ namespace CodingSeb.Localization.Loaders
         /// <param name="loader">The loader to load each translation</param>
         public void LoadFile(string fileName, LocalizationLoader loader)
         {
-            LoadStream(File.Open(fileName), loader);
+            LoadFromString(File.ReadAllText(fileName), loader, fileName);
         }
 
-        public void LoadStream(Stream stream, LocalizationLoader loader)
+        /// <summary>
+        /// Load all translations defined in Json format from the specified <paramref name="jsonString"/>.
+        /// </summary>
+        /// <param name="jsonString">String to load serialized Json format translations from.</param>
+        /// <param name="loader">The loader to use for loading translations from the string.</param>
+        /// <param name="sourceFileName">Optional source file name.</param>
+        public void LoadFromString(string jsonString, LocalizationLoader loader, string sourceFileName = "")
         {
-            using (StreamReader reader = File.OpenText(fileName))
-            {
-                JObject root = (JObject)JToken.ReadFrom(new JsonTextReader(reader));
+            JObject root = (JObject)JsonConvert.DeserializeObject(jsonString);
 
-                root.Properties().ToList()
-                    .ForEach(property => ParseSubElement(property, new Stack<string>(), loader, fileName));
-            }
+            root.Properties().ToList()
+                .ForEach(property => ParseSubElement(property, new Stack<string>(), loader, sourceFileName));
         }
 
-        private void ParseSubElement(JProperty property, Stack<string> textId, LocalizationLoader loader, string fileName)
+        private void ParseSubElement(JProperty property, Stack<string> textId, LocalizationLoader loader, string source)
         {
             switch (property.Value.Type)
             {
-                case JTokenType.Object:
-                    textId.Push(property.Name);
-                    ((JObject)property.Value).Properties().ToList()
-                        .ForEach(subProperty => ParseSubElement(subProperty, textId, loader, fileName));
-                    textId.Pop();
-                    break;
-                case JTokenType.String:
+            case JTokenType.Object:
+                textId.Push(property.Name);
+                ((JObject)property.Value).Properties().ToList()
+                    .ForEach(subProperty => ParseSubElement(subProperty, textId, loader, source));
+                textId.Pop();
+                break;
+            case JTokenType.String:
 
-                    if (LangIdDecoding == JsonFileLoaderLangIdDecoding.InFileNameBeforeExtension)
-                    {
-                        textId.Push(property.Name);
-                        loader.AddTranslation(
-                            LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix,
-                            Path.GetExtension(Regex.Replace(fileName, @"\.loc\.json", "")).Replace(".", ""),
-                            property.Value.ToString(),
-                            fileName);
-                        textId.Pop();
-                    }
-                    else if (LangIdDecoding == JsonFileLoaderLangIdDecoding.DirectoryName)
-                    {
-                        textId.Push(property.Name);
-                        loader.AddTranslation(LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix,
-                            Path.GetDirectoryName(fileName),
-                            property.Value.ToString(),
-                            fileName);
-                        textId.Pop();
-                    }
-                    else
-                    {
-                        loader.AddTranslation(LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix, property.Name, property.Value.ToString(), fileName);
-                    }
-                    break;
-                default:
-                    throw new FormatException($"Invalid format in Json language file for property [{property.Name}]");
+                if (LangIdDecoding == JsonFileLoaderLangIdDecoding.InFileNameBeforeExtension)
+                {
+                    textId.Push(property.Name);
+                    loader.AddTranslation(
+                        LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix,
+                        Path.GetExtension(Regex.Replace(source, @"\.loc\.json", "")).Replace(".", ""),
+                        property.Value.ToString(),
+                        source);
+                    textId.Pop();
+                }
+                else if (LangIdDecoding == JsonFileLoaderLangIdDecoding.DirectoryName)
+                {
+                    textId.Push(property.Name);
+                    loader.AddTranslation(LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix,
+                        Path.GetDirectoryName(source),
+                        property.Value.ToString(),
+                        source);
+                    textId.Pop();
+                }
+                else
+                {
+                    loader.AddTranslation(LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix, property.Name, property.Value.ToString(), source);
+                }
+                break;
+            default:
+                throw new FormatException($"Invalid format in Json language file for property [{property.Name}]");
             }
         }
     }

--- a/CodingSeb.Localization.JsonFileLoader/JsonFileLoader.cs
+++ b/CodingSeb.Localization.JsonFileLoader/JsonFileLoader.cs
@@ -54,6 +54,11 @@ namespace CodingSeb.Localization.Loaders
         /// <param name="loader">The loader to load each translation</param>
         public void LoadFile(string fileName, LocalizationLoader loader)
         {
+            LoadStream(File.Open(fileName), loader);
+        }
+
+        public void LoadStream(Stream stream, LocalizationLoader loader)
+        {
             using (StreamReader reader = File.OpenText(fileName))
             {
                 JObject root = (JObject)JToken.ReadFrom(new JsonTextReader(reader));

--- a/CodingSeb.Localization.YamlFileLoader/YamlFileLoader.cs
+++ b/CodingSeb.Localization.YamlFileLoader/YamlFileLoader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 using System.Text.RegularExpressions;
 using YamlDotNet.RepresentationModel;
 
@@ -47,13 +48,24 @@ namespace CodingSeb.Localization.Loaders
         }
 
         /// <summary>
-        /// Load all translation defined in Json format in the specified file
+        /// Load all translation defined in Yaml format in the specified file
         /// </summary>
         /// <param name="fileName">The file we want to load</param>
         /// <param name="loader">The loader to load each translation</param>
         public void LoadFile(string fileName, LocalizationLoader loader)
         {
-            var input = new StringReader(File.ReadAllText(fileName));
+            LoadFromString(File.ReadAllText(fileName), loader, fileName);
+        }
+
+        /// <summary>
+        /// Load all translations defined in Yaml format from the specified <paramref name="yamlString"/>.
+        /// </summary>
+        /// <param name="yamlString">String to load serialized Yaml format translations from.</param>
+        /// <param name="loader">The loader to use for loading translations from the string.</param>
+        /// <param name="sourceFileName">Optional source file name.</param>
+        public void LoadFromString(string yamlString, LocalizationLoader loader, string sourceFileName = "")
+        {
+            var input = new StringReader(yamlString);
             var yaml = new YamlStream();
 
             yaml.Load(input);
@@ -61,16 +73,16 @@ namespace CodingSeb.Localization.Loaders
             var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
 
             mapping.ToList()
-                .ForEach(pair => ParseSubElement(pair, new Stack<string>(), loader, fileName));
+                .ForEach(pair => ParseSubElement(pair, new Stack<string>(), loader, sourceFileName));
         }
 
-        private void ParseSubElement(KeyValuePair<YamlNode, YamlNode> nodePair, Stack<string> textId, LocalizationLoader loader, string fileName)
+        private void ParseSubElement(KeyValuePair<YamlNode, YamlNode> nodePair, Stack<string> textId, LocalizationLoader loader, string source)
         {
             if (nodePair.Value is YamlMappingNode mappingNode)
             {
                 textId.Push(nodePair.Key.ToString());
                 mappingNode.ToList()
-                    .ForEach(pair => ParseSubElement(pair, textId, loader, fileName));
+                    .ForEach(pair => ParseSubElement(pair, textId, loader, source));
                 textId.Pop();
             }
             else
@@ -80,9 +92,9 @@ namespace CodingSeb.Localization.Loaders
                     textId.Push(nodePair.Key.ToString());
                     loader.AddTranslation(
                         LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix,
-                        Path.GetExtension(Regex.Replace(fileName, @"\.loc\.yaml", "")).Replace(".", ""),
+                        Path.GetExtension(Regex.Replace(source, @"\.loc\.yaml", "")).Replace(".", ""),
                         nodePair.Value.ToString(),
-                        fileName);
+                        source);
                     textId.Pop();
                 }
                 else if (LangIdDecoding == YamlFileLoaderLangIdDecoding.DirectoryName)
@@ -90,14 +102,14 @@ namespace CodingSeb.Localization.Loaders
                     textId.Push(nodePair.Key.ToString());
                     loader.AddTranslation(
                         LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix,
-                        Path.GetDirectoryName(fileName),
+                        Path.GetDirectoryName(source),
                         nodePair.Value.ToString(),
-                        fileName);
+                        source);
                     textId.Pop();
                 }
                 else
                 {
-                    loader.AddTranslation(LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix, nodePair.Key.ToString(), nodePair.Value.ToString(), fileName);
+                    loader.AddTranslation(LabelPathRootPrefix + string.Join(LabelPathSeparator, textId.Reverse()) + LabelPathSuffix, nodePair.Key.ToString(), nodePair.Value.ToString(), source);
                 }
             }
         }

--- a/CodingSeb.Localization.YamlFileLoader/YamlFileLoader.cs
+++ b/CodingSeb.Localization.YamlFileLoader/YamlFileLoader.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text.RegularExpressions;
 using YamlDotNet.RepresentationModel;
 


### PR DESCRIPTION
I needed to be able to load translations directly from embedded resources in an assembly without writing them to the disk. Currently, it isn't possible to use the built-in `JsonFileLoader` & `YamlFileLoader` to manually load from non-file sources.  

This PR implements methods to support loading translations directly from serialized strings, to allow using the parsing capabilities of the built-in file loaders without an actual file.

- Added `LoadFromString` to `JsonFileLoader.cs`
- Added `LoadFromString` to `YamlFileLoader.cs`
- Renamed `fileName` parameter in `ParseSubElement` to `source` to better describe its purpose (the name also matches the source parameter in `LocalizationLoader.AddTranslation`)
- Fixed comments in `YamlFileLoader.cs` referring to Json format

Usage example:
```csharp
string serializedJson = "..."; //< this can come from a stream, file, or anywhere else you can get data from

var jsonFileLoader = new JsonFileLoader();
LocalizationLoader.Instance.FileLanguageLoaders.Add(jsonFileLoader);

jsonFileLoader.LoadFromString(serializedJson, LocalizationLoader.Instance);
```